### PR TITLE
Atualizando dependências no requirements.txt para melhor compatibilidade

### DIFF
--- a/rotinas_complementares_pto_controle/requirements.txt
+++ b/rotinas_complementares_pto_controle/requirements.txt
@@ -1,4 +1,9 @@
-pypdf2
-secretary
-psycopg2
-opencv-python
+Jinja2==2.11.3
+markdown2==2.5.3
+MarkupSafe==2.0.1
+numpy==2.2.2
+opencv-python==4.11.0.86
+psycopg2==2.9.10
+psycopg2-binary==2.9.10
+PyPDF2==3.0.1
+secretary==0.2.19


### PR DESCRIPTION
A versão mais recente do Jinja2 (3.1.5, instalada automaticamente ao executar pip install jinja2) não inclui mais o componente Markup, que foi removido a partir da versão 3.x. Para resolver esse problema, há duas opções:

Atualizar o código para se adequar às mudanças no Jinja2.
Fixar uma versão específica do Jinja2 no requirements.txt, garantindo compatibilidade com o código existente.
Recomenda-se que o requirements.txt defina uma versão específica para garantir estabilidade, especialmente ao usar ambientes virtuais. Além disso, sugere-se a atualização do README com os procedimentos de instalação para evitar problemas futuros.